### PR TITLE
Add support for another listening path in python

### DIFF
--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 imgui/1.92.4
+argparse/3.2
 
 [generators]
 CMakeDeps

--- a/lib/py_bindings/src/lib_py.cc
+++ b/lib/py_bindings/src/lib_py.cc
@@ -36,13 +36,14 @@ namespace rtm
         nb::class_<Probe>(m, "Probe")
             .def(nb::init<>())
             .def("init", [](Probe& self, char const* process, char const* task,
-                            uint32_t period_ms, int32_t priority, nanoseconds start)
+                            uint32_t period_ms, int32_t priority, nanoseconds start,
+                            std::string_view listening_path)
                 {
-                    auto io = std::make_unique<rtm::LocalSocket>();
+                    auto io = std::make_unique<rtm::LocalSocket>(listening_path);
                     auto rc = io->open(rtm::access::Mode::READ_WRITE);
                     if (rc)
                     {
-                        throw std::runtime_error("Cannot connect ot the recorder");
+                        throw std::runtime_error("Cannot connect to the recorder");
                     }
 
                     self.init(process, task,
@@ -50,7 +51,8 @@ namespace rtm
                         std::move(io));
                 }, "process"_a, "task"_a,
                    "period_ms"_a, "priority"_a,
-                   "start"_a = start_time())
+                   "start"_a = start_time(),
+                   "listening_path"_a = DEFAULT_LISTENING_PATH)
             .def("log", [](Probe& self)
                 {
                     self.log();

--- a/py_bindings/examples/probe.py
+++ b/py_bindings/examples/probe.py
@@ -1,8 +1,20 @@
+import argparse
 import time
 from real_time_monitor import Probe
 
+parser = argparse.ArgumentParser(description="Real-time probe example (sends data to rtm_recorder).")
+parser.add_argument(
+    "--listening_path", "-l",
+    default=None,
+    help="Unix socket path where the recorder is listening (omit to use the default)",
+)
+args = parser.parse_args()
+
 p = Probe()
-p.init(process="python", task="my_task", period_ms=1, priority=42)
+if args.listening_path is not None:
+    p.init(process="python", task="my_task", period_ms=1, priority=42, listening_path=args.listening_path)
+else:
+    p.init(process="python", task="my_task", period_ms=1, priority=42)
 
 TARGET = 0.001  # 1 ms
 

--- a/tools/recorder/CMakeLists.txt
+++ b/tools/recorder/CMakeLists.txt
@@ -1,5 +1,7 @@
+find_package(argparse REQUIRED)
+
 add_executable(rtm_recorder main.cc)
-target_link_libraries(rtm_recorder PRIVATE rtm)
+target_link_libraries(rtm_recorder PRIVATE rtm argparse::argparse)
 
 if (SKBUILD)
     install(TARGETS rtm_recorder DESTINATION ${SKBUILD_SCRIPTS_DIR})


### PR DESCRIPTION
Bonus: Improve rtm_recorder cmdline with argparse library