### PR TITLE
fix disappearing plot when zooming in

### DIFF
--- a/monitor/serie.cc
+++ b/monitor/serie.cc
@@ -106,7 +106,7 @@ namespace rtm
         {
             auto it = std::find_if(sections_.begin(), sections_.end(), [&](Section const& s)
             {
-                return (s.min.count() < (limits.X.Min + 1000)) or (s.max.count() > limits.X.Max);
+                return (s.min.count() > limits.X.Min) and (s.max.count() >= limits.X.Max);
             });
             if (it == sections_.end())
             {

--- a/tools/generator/main.cc
+++ b/tools/generator/main.cc
@@ -3,11 +3,11 @@
 
 using namespace std::chrono;
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
     if (argc != 2)
     {
-        printf("Usage: /generator [samples]\n");
+        printf("Usage: ./generator [samples]\n");
         return 1;
     }
 
@@ -26,27 +26,9 @@ int main(int argc, char* argv[])
 
     rtm::Probe probe;
     probe.init("generator", "one_task",
-            START, 1ms, 42,
-            std::move(io));
+               START, 1ms, 42,
+               std::move(io));
 
-    nanoseconds now = START + 20ms;
-    for (int i = 0; i < 100000; ++i)
-    {
-        nanoseconds tick = now + i * 1ms + (100 - rand() % 200) * 1us;
-        probe.log(tick);
-        probe.log(tick + (rand() % 500 + 50) * 1us);
-    }
-
-    now += 25min;
-    for (int i = 0; i < 100000; ++i)
-    {
-        nanoseconds tick = now + i * 1ms + (100 - rand() % 200) * 1us;
-        probe.log(tick);
-        probe.log(tick + (rand() % 500 + 50) * 1us);
-    }
-
-
-/*
     uint64_t period = 1;
     uint64_t save_period = 0;
     for (uint64_t i = 1; i < samples; i += period)
@@ -76,7 +58,6 @@ int main(int argc, char* argv[])
         probe.log(now);
         probe.log(now + (rand() % 500 + period * 50) * 1us);
     }
-        */
     probe.flush();
 
     return 0;


### PR DESCRIPTION
Fix section lookup logic causing disappearing lines

The find_if condition was using OR instead of AND, causing incorrect 
section matching. Reverted to original logic that properly finds sections 
containing the visible plot range.

Original: (s.min > X.Min) AND (s.max >= X.Max) - finds containing section
Broken:   (s.min < X.Min+1000) OR (s.max > X.Max) - matches too broadly

### Before [main]:
![bug](https://github.com/user-attachments/assets/eb7d777a-2a13-4afd-bdee-2760704df585)

### After:
![working](https://github.com/user-attachments/assets/3bce1548-c6f2-4dcf-ad73-00de897fae44)
